### PR TITLE
fix: clear graph_min/graph_max when disabling per-entity overrides

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -432,6 +432,8 @@ export class BackgroundGraphEntitiesEditor extends LitElement implements Lovelac
         delete newEntityConf.line_color;
         delete newEntityConf.line_opacity;
         delete newEntityConf.color_thresholds;
+        delete newEntityConf.graph_min;
+        delete newEntityConf.graph_max;
       }
       return newEntityConf;
     });


### PR DESCRIPTION
_overwriteAppearanceChanged() already deletes line_color, line_opacity, and color_thresholds when "Optional overrides" is turned off, but left graph_min/graph_max behind. This leaves old Y-axis bounds in the config that reappear if the toggle is re enabled later.