### PR TITLE
build(e2e): add .dockerignore so a stale host node_modules can't break the container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Keep the host's node_modules out of `COPY . .` — it silently overwrites the
+# image's fresh `npm ci` and breaks Playwright when the host install is stale.
+node_modules
+.git
+playwright-report
+test-results
+test/e2e/screenshots


### PR DESCRIPTION
`Dockerfile.e2e` runs `npm ci`, then `COPY . .` copies the host's `node_modules` over it. With a stale host install the failure is confusing: every e2e test fails with a Playwright browser/version mismatch (hit this with 1.59.1 on the host vs 1.62.1 in the lockfile and image tag).

Adds a `.dockerignore` so the container always tests the lockfile's install; also keeps `.git` and test artifacts out of the build context. Verified with an uncached image rebuild — all e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
